### PR TITLE
Export notebooks in run mode for autorun on load

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,19 +22,19 @@ jobs:
           pip install marimo nbformat
 
       - name: Export demand management app as HTML
-        run: marimo export html-wasm apps/demand_management.py -o site/demand_management --mode edit
+        run: marimo export html-wasm apps/demand_management.py -o site/demand_management --mode run
 
       - name: Export demand management app as Jupyter Notebook
         run: marimo export ipynb apps/demand_management.py -o site/downloads/demand_management.ipynb
 
       - name: Export inventory management app as HTML
-        run: marimo export html-wasm apps/inventory_management.py -o site/inventory_management --mode edit
+        run: marimo export html-wasm apps/inventory_management.py -o site/inventory_management --mode run
 
       - name: Export inventory management app as Jupyter Notebook
         run: marimo export ipynb apps/inventory_management.py -o site/downloads/inventory_management.ipynb
 
       - name: Export vehicle routing app as HTML
-        run: MARIMO_OUTPUT_MAX_BYTES=20000000 marimo export html-wasm apps/vehicle_routing.py -o site/vehicle_routing --mode edit
+        run: MARIMO_OUTPUT_MAX_BYTES=20000000 marimo export html-wasm apps/vehicle_routing.py -o site/vehicle_routing --mode run
 
       - name: Export vehicle routing app as Jupyter Notebook
         run: marimo export ipynb apps/vehicle_routing.py -o site/downloads/vehicle_routing.ipynb


### PR DESCRIPTION
## Changes

- Changed all WASM notebook exports from `--mode edit` to `--mode run`
- Notebooks will now automatically execute when loaded in the browser
- Code will be readonly (not editable in the browser)

## Affected Notebooks

- demand_management.py
- inventory_management.py
- vehicle_routing.py

## Benefits

- Better user experience - viewers see results immediately
- No need to manually click "Run all" on each notebook
- Consistent with presentation/demo use case

## Trade-offs

- Code becomes readonly in the browser (can still be edited locally)
- Users cannot modify and re-run code in the deployed version