### PR TITLE
Add Center of Gravity notebook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Export vehicle routing app as Jupyter Notebook
         run: marimo export ipynb apps/vehicle_routing.py -o site/downloads/vehicle_routing.ipynb
 
+      - name: Export center of gravity app as HTML
+        run: marimo export html-wasm apps/center_of_gravity.py -o site/center_of_gravity --mode edit
+
+      - name: Export center of gravity app as Jupyter Notebook
+        run: marimo export ipynb apps/center_of_gravity.py -o site/downloads/center_of_gravity.ipynb
+
       - name: Upload Pages Artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Add interactive Center of Gravity (CoG) marimo notebook for warehouse location planning
- Include Spain pharmacy demand data and supporting images
- Add notebook to GitHub Pages deployment workflow

## Changes
- `apps/center_of_gravity.py` - New marimo notebook covering:
  - Single warehouse CoG calculation for Spain
  - Multi-warehouse regional CoG approach
  - Interactive visualizations with folium maps
- `apps/public/cog/` - Data files and images for the notebook
- `.github/workflows/deploy.yml` - Add CoG app to deployment

## Test plan
- [x] Verify notebook runs locally with `marimo edit apps/center_of_gravity.py`
- [x] Check GitHub Actions build succeeds
- [x] Confirm deployment at https://d3group.github.io/OM-lecture/center_of_gravity/