### PR TITLE
Fix Altair 6.x compatibility warning in center_of_gravity

### DIFF
--- a/apps/center_of_gravity.py
+++ b/apps/center_of_gravity.py
@@ -818,7 +818,7 @@ def _(alt, pl):
         Create an interactive chart where points can be clicked to select/unselect.
         The CoG is calculated and displayed dynamically based on selection.
         """
-        points = create_cog_example_data()
+        points = create_cog_example_data().to_pandas()
 
         # Create click selection (multi-select with toggle, start empty)
         # toggle='true' (string) makes every click toggle without needing shift key


### PR DESCRIPTION
## Summary
- Convert polars DataFrame to pandas before passing to Altair to avoid narwhals compatibility warning

## Issue
Altair 6.x uses narwhals internally, which triggers a warning when passing polars DataFrames directly:
```
UserWarning: You passed a `<class 'narwhals.stable.v1.DataFrame'>` to `is_pandas_dataframe`.
```

## Fix
Added `.to_pandas()` conversion in `create_interactive_cog_chart()` function.