### PR TITLE
fix: Add pyarrow to micropip packages for WASM mode

### DIFF
--- a/apps/center_of_gravity.py
+++ b/apps/center_of_gravity.py
@@ -66,7 +66,8 @@ async def _():
             "polars",
             "altair",
             "requests",
-            "folium"
+            "folium",
+            "pyarrow"
         ]
 
         for pkg in packages:

--- a/apps/warehouse_location_part_1.py
+++ b/apps/warehouse_location_part_1.py
@@ -67,7 +67,8 @@ async def _():
             "altair",
             "requests",
             "folium",
-            "numpy"
+            "numpy",
+            "pyarrow"
         ]
 
         for pkg in packages:

--- a/apps/warehouse_location_part_2.py
+++ b/apps/warehouse_location_part_2.py
@@ -67,7 +67,8 @@ async def _():
             "altair",
             "requests",
             "folium",
-            "pulp"
+            "pulp",
+            "pyarrow"
         ]
 
         for pkg in packages:


### PR DESCRIPTION
## Summary
- Added `pyarrow` to the micropip packages list in all 3 notebooks
- Fixes `ModuleNotFoundError: pa.Table requires 'pyarrow' module to be installed` error in WASM mode
- `polars.DataFrame.to_pandas()` requires pyarrow internally

## Files Changed
- `apps/center_of_gravity.py`
- `apps/warehouse_location_part_1.py`
- `apps/warehouse_location_part_2.py`

## Test plan
- [ ] Verify center_of_gravity notebook loads without errors in WASM mode
- [ ] Verify warehouse_location_part_1 notebook loads without errors in WASM mode
- [ ] Verify warehouse_location_part_2 notebook loads without errors in WASM mode