### PR TITLE
fix: Suppress altair/narwhals warning and fix data URL paths

### DIFF
--- a/apps/center_of_gravity.py
+++ b/apps/center_of_gravity.py
@@ -91,6 +91,8 @@ def _():
     import requests
     import folium
     from typing import Optional
+    import warnings
+    warnings.filterwarnings("ignore", message=".*narwhals.*is_pandas_dataframe.*")
     return alt, folium, mo, np, pl, requests
 
 

--- a/apps/warehouse_location_part_1.py
+++ b/apps/warehouse_location_part_1.py
@@ -48,7 +48,7 @@ def _():
             IMG_BASE = "apps/public/wlp/images"
         else:
             # WASM/deployed mode - use GitHub raw URLs for data files
-            BASE = raw_url("apps", "public", "cog", "data")
+            BASE = raw_url("apps", "public", "wlp", "data")
             IMG_BASE = "public/wlp/images"  # Images work with relative paths
 
     print(f"Using BASE: {DataURLs.BASE}")
@@ -89,6 +89,8 @@ def _():
     import altair as alt
     import polars as pl
     import numpy as np
+    import warnings
+    warnings.filterwarnings("ignore", message=".*narwhals.*is_pandas_dataframe.*")
     return alt, mo, np, pl
 
 

--- a/apps/warehouse_location_part_2.py
+++ b/apps/warehouse_location_part_2.py
@@ -48,7 +48,7 @@ def _():
             IMG_BASE = "apps/public/wlp/images"
         else:
             # WASM/deployed mode - use GitHub raw URLs for data files
-            BASE = raw_url("apps", "public", "cog", "data")
+            BASE = raw_url("apps", "public", "wlp", "data")
             IMG_BASE = "public/wlp/images"  # Images work with relative paths
 
     print(f"Using BASE: {DataURLs.BASE}")
@@ -91,6 +91,8 @@ def _():
     import numpy as np
     import pulp
     import folium
+    import warnings
+    warnings.filterwarnings("ignore", message=".*narwhals.*is_pandas_dataframe.*")
     return folium, mo, np, pl, pulp
 
 


### PR DESCRIPTION
## Summary
- Added warnings filter to suppress narwhals `is_pandas_dataframe` warning in Altair 6.x
- Fixed `warehouse_location_part_1.py` and `warehouse_location_part_2.py` to use correct `wlp` data path instead of `cog`

## Files Changed
- `apps/center_of_gravity.py` - added warnings filter
- `apps/warehouse_location_part_1.py` - added warnings filter + fixed data URL
- `apps/warehouse_location_part_2.py` - added warnings filter + fixed data URL

## Test plan
- [ ] Verify center_of_gravity notebook runs without narwhals warning
- [ ] Verify warehouse_location_part_1 loads correct data in WASM mode
- [ ] Verify warehouse_location_part_2 loads correct data in WASM mode