### PR TITLE
fix: Use HiGHS solver instead of CBC for WASM compatibility

### DIFF
--- a/apps/warehouse_location_part_2.py
+++ b/apps/warehouse_location_part_2.py
@@ -68,7 +68,8 @@ async def _():
             "requests",
             "folium",
             "pulp",
-            "pyarrow"
+            "pyarrow",
+            "highspy"
         ]
 
         for pkg in packages:
@@ -846,8 +847,8 @@ def _(mo, sc):
 
 @app.cell(hide_code=True)
 def _(J, problem, pulp, y):
-    # Solve the problem with the default solver
-    status = problem.solve(pulp.PULP_CBC_CMD(msg=False))
+    # Solve the problem with HiGHS solver (works in WASM, unlike CBC which uses subprocess)
+    status = problem.solve(pulp.HiGHS(msg=False))
     open_warehouses = [j for j in J if y[j].value() > 0.5]
     return (open_warehouses,)
 


### PR DESCRIPTION
## Summary
- Changed PuLP solver from `PULP_CBC_CMD` to `HiGHS` in warehouse_location_part_2.py
- Added `highspy` to micropip packages list

## Problem
CBC solver uses `subprocess.Popen` which fails in Pyodide/WASM:
```
OSError: [Errno 138] emscripten does not support processes.
```

## Solution
PuLP's `HiGHS` solver uses `highspy` directly without subprocess. Since Pyodide includes `highspy` (v1.11.0), this works in WASM.

## Test plan
- [ ] Verify warehouse_location_part_2 notebook solves optimization problem in WASM mode