### PR TITLE
fix: Use scipy HiGHS solver for WASM compatibility

### DIFF
--- a/apps/vehicle_routing.py
+++ b/apps/vehicle_routing.py
@@ -101,6 +101,8 @@ def _():
     import numpy as np
     from typing import Iterable, Optional
     from folium import plugins
+    import warnings
+    warnings.filterwarnings("ignore", message=".*narwhals.*is_pandas_dataframe.*")
     return (
         Iterable,
         Optional,


### PR DESCRIPTION
## Summary
- Replace PuLP's CBC solver with `scipy.optimize.linprog(method='highs')` in warehouse_location_part_2.py
  - CBC uses subprocess which is not supported in WASM/Pyodide
  - Added `pulp_to_scipy_linprog()` and `solve_with_scipy()` helper functions to convert PuLP models
  - Removed `highspy` from micropip packages (not available as pure Python wheel)
- Added narwhals warning filter to vehicle_routing.py

## Test plan
- [ ] Test warehouse_location_part_2.py WASM export - verify solver works without subprocess errors
- [ ] Test vehicle_routing.py WASM export - verify no altair/narwhals warnings